### PR TITLE
Fix to avoid duplicate order confirmation emails sending

### DIFF
--- a/Model/Checkout.php
+++ b/Model/Checkout.php
@@ -647,7 +647,8 @@ class Checkout extends \Magento\Checkout\Model\Type\Onepage
             ['order' => $order, 'quote' => $this->getQuote()]
         );
 
-        if ($order->getCanSendNewEmailFlag()) {
+        //check if order confirmation email was already sent ($order->getEmailSent() == true) to avoid sending it twice
+        if ($order->getCanSendNewEmailFlag() && !($order->getEmailSent())) {
             try {
                 $this->orderSender->send($order);
             } catch (\Exception $e) {


### PR DESCRIPTION
This is the fix for issue  #4.

The native Magento function \Magento\Quote\Observer\SubmitObserver::execute(observer) sends the order confirmation email automatically on checkout_type_onepage_save_order_after event using \Magento\Sales\Model\Order\Email\Sender\OrderSender::send(order, boolean) function. If the email was successfully sent, then $order->getEmailSent() === true, otherwise $order->getEmailSent() is null. 

No need to call the order confirmation email sending functionality forcibly if the email was already sent.
