### PR TITLE
[SuccessPage] If $order is null, early return the OnepageSuccessObserver

### DIFF
--- a/Observer/OnepageSuccessObserver.php
+++ b/Observer/OnepageSuccessObserver.php
@@ -37,7 +37,7 @@ class OnepageSuccessObserver extends Client implements ObserverInterface
     ) {
         $this->helper = $helper;
         $this->paymentApi = $paymentApi;
-       // $this->clientApi  = $clientApi;
+        // $this->clientApi  = $clientApi;
         $this->dibsOrderHandler = $dibsOrderHandler;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
         $this->cookieManager = $cookieManager;
@@ -46,13 +46,16 @@ class OnepageSuccessObserver extends Client implements ObserverInterface
 
     public function execute(EventObserver $observer)
     {
-
         $order = $observer->getEvent()->getOrder();
+        if ($order === null) {
+            return;
+        }
+
         $orderId = $order->getIncrementId();
         $payment = $order->getPayment();
         $method = $payment->getMethodInstance();
         $methodTitle = $method->getTitle();
-        if($payment->getMethod() == "dibseasycheckout"){
+        if ($payment->getMethod() == "dibseasycheckout") {
             $paymentId = $order->getDibsPaymentId();
             $reference = new UpdatePaymentReference();
             $reference->setReference($order->getIncrementId());
@@ -62,7 +65,7 @@ class OnepageSuccessObserver extends Client implements ObserverInterface
                 $checkoutUrl = $payment->getCheckoutUrl();
                 $reference->setCheckoutUrl($checkoutUrl);
             }
-            
+
             $this->paymentApi->UpdatePaymentReference($reference, $paymentId);
         }
     }


### PR DESCRIPTION
Hello there.

When used with Klarna, the Klarna successpage can error out with an exception coming from this Observer - because at the time when this Observer is invoked - the $order is actually null.

Leading to an Exception being thrown halting the successpage from loading.

A simple fix for this was simply to not run the observer if the $order object is null.