### PR TITLE
Syntax error in constructor method parameter.

### DIFF
--- a/Observer/UpdatePaymentReferenceOnSubmitAllObserver.php
+++ b/Observer/UpdatePaymentReferenceOnSubmitAllObserver.php
@@ -18,7 +18,7 @@ class UpdatePaymentReferenceOnSubmitAllObserver implements ObserverInterface
 
     public function __construct(
         Data $helper,
-        Payment $api,
+        Payment $api
     ) {
         $this->api    = $api;
         $this->helper = $helper;


### PR DESCRIPTION
PHP 7 does not allows trailing commas in constructer and closure. This fix helps to preventing syntax error that i shared:  syntax error, unexpected ')', expecting variable (T_VARIABLE) in /var/www/html/vendor/nexi-checkout/magento2/Observer/UpdatePaymentReferenceOnSubmitAllObserver.php on line 22