### PR TITLE
Make logo clickable in payment section

### DIFF
--- a/view/frontend/web/template/payment/checkout.html
+++ b/view/frontend/web/template/payment/checkout.html
@@ -4,8 +4,10 @@
                name="payment[method]"
                class="radio"
                data-bind="attr: {'id': getCode()}, value: getCode(), checked: isChecked, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
-        <img data-bind="attr: {'src': getLogoUrl(), height : '60', width : '90'}" class="payment-icon" />
-        <label data-bind="attr: {'for': getCode()}" class="label"><span data-bind="text: getTitle()"></span></label>
+        <label data-bind="attr: {'for': getCode()}" class="label">
+            <img data-bind="attr: {'src': getLogoUrl(), height : '60', width : '90'}" class="payment-icon" />
+            <span data-bind="text: getTitle()"></span>
+        </label>
     </div>
 
     <div class="payment-method-content">


### PR DESCRIPTION
Only radio and payment text were clickable, not the logo itself.  

This is different from the standard way Magento payment UX works, so this patch corrects that.